### PR TITLE
Remove az client form terraform workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   IMAGE_TAG: '1.0.${{ github.run_number }}'
-  IMAGE_NAME: 'techchallengeapp'
+  IMAGE_NAME: 'eliasm50/techchallengeapp'
   AZURE_WEBAPP_NAME: chappweb   # Azure App Service Name   
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,11 @@ on:
 
 env:
   imageTag: '1.0.${{ github.run_number }}'
-  AZURE_WEBAPP_NAME: chappweb   # Azure App Service Name 
-  CONTAINER_REGISTRY: ghcr.io
+  AZURE_WEBAPP_NAME: chappweb   # Azure App Service Name   
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
-    # if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
     steps:
       - name: Extract Version
         id: version_step
@@ -62,6 +60,11 @@ jobs:
           build-args: |
             ${{steps.version_step.outputs.version}}
 
+  deploy-ci:
+    needs: build 
+    runs-on: ubuntu-latest
+    environment: ci
+    steps:
       - name: Login via Az module
         uses: azure/login@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@ on:
       - master
 
 env:
-  imageTag: '1.0.${{ github.run_number }}'
+  IMAGE_TAG: '1.0.${{ github.run_number }}'
+  IMAGE_NAME: 'techchallengeapp'
   AZURE_WEBAPP_NAME: chappweb   # Azure App Service Name   
 
 jobs:
@@ -20,8 +21,8 @@ jobs:
         id: version_step
         run: |
           echo "##[set-output name=version;]VERSION=${GITHUB_REF#$"refs/tags/v"}"
-          echo "##[set-output name=version_tag;]$GITHUB_REPOSITORY:${{ env.imageTag }}"
-          echo "##[set-output name=latest_tag;]$GITHUB_REPOSITORY:latest"
+          echo "##[set-output name=version_tag;]${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}"
+          echo "##[set-output name=latest_tag;]${{ env.IMAGE_NAME }}:latest"
 
       - name: Print Version
         run: |
@@ -76,7 +77,7 @@ jobs:
         uses: azure/webapps-deploy@v2
         with:
           app-name: ${{ env.AZURE_WEBAPP_NAME }}-ci-app
-          images: ${{ env.VERSION_TAG }}
+          images: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
           startup-command: serve
 
       # Azure logout

--- a/.github/workflows/infrastructure.deploy.yml
+++ b/.github/workflows/infrastructure.deploy.yml
@@ -45,5 +45,5 @@ jobs:
       # On push to master, build or change infrastructure according to Terraform configuration files
       # Note: It is recommended to set up a required "strict" status check in your repository for "Terraform Cloud". See the documentation on "strict" required status checks for more information: https://help.github.com/en/github/administering-a-repository/types-of-required-status-checks
     - name: Terraform Apply
-      if: github.ref == 'refs/heads/master'
+      #if: github.ref == 'refs/heads/master'
       run: terraform apply -var-file="vars/env.ci.tfvars" -auto-approve

--- a/.github/workflows/infrastructure.deploy.yml
+++ b/.github/workflows/infrastructure.deploy.yml
@@ -45,5 +45,5 @@ jobs:
       # On push to master, build or change infrastructure according to Terraform configuration files
       # Note: It is recommended to set up a required "strict" status check in your repository for "Terraform Cloud". See the documentation on "strict" required status checks for more information: https://help.github.com/en/github/administering-a-repository/types-of-required-status-checks
     - name: Terraform Apply
-      #if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master'
       run: terraform apply -var-file="vars/env.ci.tfvars" -auto-approve

--- a/.github/workflows/infrastructure.deploy.yml
+++ b/.github/workflows/infrastructure.deploy.yml
@@ -1,4 +1,4 @@
-name: 'Infrastructure Deploy Worflow'
+name: 'Infrastructure Deploy Workflow'
 
 on: workflow_dispatch
 
@@ -24,12 +24,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Login via Az module
-      uses: azure/login@v1
-      with:
-        creds: ${{secrets.AZURE_CREDENTIALS}}
-        enable-AzPSSession: true       
-
     # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v1
@@ -53,8 +47,3 @@ jobs:
     - name: Terraform Apply
       if: github.ref == 'refs/heads/master'
       run: terraform apply -var-file="vars/env.ci.tfvars" -auto-approve
-
-     # Azure logout
-    - name: logout
-      run: |
-        az logout

--- a/.github/workflows/infrastructure.destroy.yml
+++ b/.github/workflows/infrastructure.destroy.yml
@@ -35,5 +35,5 @@ jobs:
       # On push to master, build or change infrastructure according to Terraform configuration files
       # Note: It is recommended to set up a required "strict" status check in your repository for "Terraform Cloud". See the documentation on "strict" required status checks for more information: https://help.github.com/en/github/administering-a-repository/types-of-required-status-checks
     - name: Terraform Destroy
-      if: github.ref == 'refs/heads/master'
+      #if: github.ref == 'refs/heads/master'
       run: terraform destroy -var-file="vars/env.ci.tfvars" -auto-approve

--- a/.github/workflows/infrastructure.destroy.yml
+++ b/.github/workflows/infrastructure.destroy.yml
@@ -35,5 +35,5 @@ jobs:
       # On push to master, build or change infrastructure according to Terraform configuration files
       # Note: It is recommended to set up a required "strict" status check in your repository for "Terraform Cloud". See the documentation on "strict" required status checks for more information: https://help.github.com/en/github/administering-a-repository/types-of-required-status-checks
     - name: Terraform Destroy
-      #if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master'
       run: terraform destroy -var-file="vars/env.ci.tfvars" -auto-approve

--- a/.github/workflows/infrastructure.destroy.yml
+++ b/.github/workflows/infrastructure.destroy.yml
@@ -1,4 +1,4 @@
-name: 'Infrastructure Destroy Worflow'
+name: 'Infrastructure Destroy Workflow'
 
 on: workflow_dispatch
 
@@ -24,12 +24,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Login via Az module
-      uses: azure/login@v1
-      with:
-        creds: ${{secrets.AZURE_CREDENTIALS}}
-        enable-AzPSSession: true       
-
     # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v1
@@ -43,8 +37,3 @@ jobs:
     - name: Terraform Destroy
       if: github.ref == 'refs/heads/master'
       run: terraform destroy -var-file="vars/env.ci.tfvars" -auto-approve
-
-     # Azure logout
-    - name: logout
-      run: |
-        az logout

--- a/.github/workflows/seeddb.yml
+++ b/.github/workflows/seeddb.yml
@@ -2,14 +2,13 @@ name: Seed db Workflow
 on: workflow_dispatch
 
 env:
-  imageTag: '1.0.${{ github.run_number }}'
+  image: 'eliasm50/techchallengeapp:latest'
   AZURE_WEBAPP_NAME: chappweb   # Azure App Service Name 
-  CONTAINER_REGISTRY: ghcr.io
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    # if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
+    environment: ci
     steps:
       - name: Login via Az module
         uses: azure/login@v1
@@ -22,7 +21,7 @@ jobs:
         uses: azure/webapps-deploy@v2
         with:
           app-name: ${{ env.AZURE_WEBAPP_NAME }}-ci-app
-          images: eliasm50/techchallengeapp:latest
+          images: ${{ env.image }}
           startup-command: seeddb
 
       # Azure logout


### PR DESCRIPTION
### Description

- az-cli from terraform removed since is no longer required for GitHub action. (it was used for a local exec for seeding initially)
- deploy job for ci/cd workflow to deploy to ci on a successful build added
- typos correction


Fixes: https://github.com/servian/TechChallengeApp/issues/{issue number}

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [ ] Added issue number to `Fixes` line above
